### PR TITLE
fix: Correctly handle registry prefix

### DIFF
--- a/gopass/gopass.go
+++ b/gopass/gopass.go
@@ -133,7 +133,7 @@ func (h *Handler) Get(url string) (string, string, error) {
 		base64.URLEncoding.EncodeToString([]byte(url)),
 	)
 
-	matches, err := h.listByPrefix(prefix)
+	matches, err := h.listByPrefix(prefix+"/")
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
When listing by prefix, this should ensure the `/` is added at the end, otherwise URLs for subdomains, etc are also included in the results, leading to finding multiple logins, when in reality only one exists.

As an example, logging in to Docker Hub via `docker login` results in the following entries  in the gopass store:

```
gopass
└── io.container.registries/
    ├── aHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEv/
    │   └── dGVzdHVzZXIK
    ├── aHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEvYWNjZXNzLXRva2Vu/
    │   └── dGVzdHVzZXIK
    └── aHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEvcmVmcmVzaC10b2tlbg==/
        └── dGVzdHVzZXIK
```

Entries are created for:

https://index.docker.io/v1/
https://index.docker.io/v1/access-token
https://index.docker.io/v1/refresh-token

When listing these are seen as multiple logins, where in reality they are a single login (in the case above for `testuser`).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

